### PR TITLE
20200709 explicit py pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,11 @@ jobs:
 workflows:
   build_all_images:
     jobs:
-      - windows_visualstudio_aws
+      - windows_visualstudio_aws:
+          filters:
+            branches:
+              only:
+                - master
 
   daily:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     - run:
         command: apk update
     - run:
-        command: apk add --no-progress python3 curl jq git bash
+        command: apk add --no-progress python3 py-pip curl jq git bash
     - run:
         command: pip3 install awscli
     - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,7 @@ jobs:
 workflows:
   build_all_images:
     jobs:
-      - windows_visualstudio_aws:
-          filters:
-            branches:
-              only:
-                - master
+      - windows_visualstudio_aws
 
   daily:
     jobs:


### PR DESCRIPTION
Due to changes in Docker images in use, `pip3` command is [no longer available without explicitly installing it](https://app.circleci.com/pipelines/github/CircleCI-Public/circleci-server-windows-image-builder/134/workflows/3f98b76c-ed1e-4bd6-b9ae-62ce691857ad/jobs/239). This change installs `py-pip`, which containes `pip3`.