### PR TITLE
Added py3-pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           command: apk update
       - run:
-          command: apk add --no-progress python3 py-pip curl jq git bash py3-pip
+          command: apk add --no-progress python3 curl jq git bash py3-pip
       - run:
           command: pip3 install awscli pyyaml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           command: apk update
       - run:
-          command: apk add --no-progress python3 py-pip curl jq git bash
+          command: apk add --no-progress python3 py-pip curl jq git bash py3-pip
       - run:
           command: pip3 install awscli pyyaml
       - run:


### PR DESCRIPTION
While working on Windows AMI, found that Python3 does not install pip3, and gives the below error, so adding `py3-pip`.

```
#!/bin/bash -eo pipefail
pip3 install awscli
/bin/bash: pip3: command not found

Exited with code exit status 127
```