### PR TITLE
Add support for image building on GCE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,48 @@
+# We will continue using config version 2 for backward compatibility with server 2.x
 version: 2
 
-jobs:
-  gc_old_ec2_instances:
-    docker:
-      - image: circleci/python:3.7
-    steps:
-      - checkout
-      - run: sudo pip3 install awscli
-      - run: sudo apt-get update && sudo apt-get install jq
-      - run: scripts/gc-ec2-instances.sh
-
-  windows_visualstudio_aws:
+library:
+  build_image: &build_image
     docker:
       - image: hashicorp/packer:1.4.5
     steps:
+      - run:
+          name: Determine which platform we use
+          command: |
+            if [ "${CIRCLE_JOB}" == "windows_visualstudio_aws" ] && [ ! -z "$AWS_DEFAULT_REGION" ]
+            then
+              echo 'export PROVIDER="amazon-ebs"' | tee -a $BASH_ENV
+            elif [ "${CIRCLE_JOB}" == "windows_visualstudio_gcp" ] && [ ! -z "$GCE_DEFAULT_ZONE" ]
+            then
+              echo 'export PROVIDER="googlecompute"' | tee -a $BASH_ENV
+            else
+              echo 'No provider available. Gracefully exiting.'
+              circleci-agent step halt
+              exit
+            fi
       - checkout
       - run: apk update
       - run: apk add --no-progress python3 curl jq
       - run: pip3 install awscli pyyaml
+      - run:
+          name: install and configure gcloud sdk as needed
+          command: |
+            if [ ! -z "${GCE_SERVICE_CREDENTIALS_BASE64}" ]
+            then
+              echo "${GCE_SERVICE_CREDENTIALS_BASE64}" \
+                | base64 -d \
+                > /tmp/gce-credentials.json
+
+              VERSION=267.0.0-linux-x86_64
+              curl --silent --show-error --location --output /tmp/google-cloud-sdk-${VERSION}.tar.gz \
+              "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${VERSION}.tar.gz"
+
+              echo "e1900f12c0dffaa96fb1435afb342e829fd814bcffba96b8c3b58d55c518f4d3  /tmp/google-cloud-sdk-${VERSION}.tar.gz" | sha256sum -c -
+
+              tar xf /tmp/google-cloud-sdk-${VERSION}.tar.gz
+
+              ./google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=/tmp/gce-credentials.json
+            fi
       - run:
           name: convert windows/visual-studio/packer.yaml to windows/visual-studio/packer.json
           command: |
@@ -39,32 +64,44 @@ jobs:
             MONOREPO_CONTENT_SHA="$(./scripts/get_content_sha windows)"
             [[ $CIRCLE_BRANCH != master ]] && IMAGE_FAMILY_SUFFIX="-dev"
 
-            WINDOWS_USER="Administrator"
+            case "${PROVIDER}" in
+              googlecompute)
+                WINDOWS_USER="circleci_packer"
+                ;;
+              amazon-ebs)
+                WINDOWS_USER="Administrator"
+                ;;
+              *)
+                echo "Unrecognized packer_provider value: ${PROVIDER}."
+                exit 1
+                ;;
+            esac
 
-            ./scripts/get_last_image "${MONOREPO_CONTENT_SHA}" "${CIRCLE_JOB}" && {
-                echo "amazon-ebs image with monorepo_content_sha = ${MONOREPO_CONTENT_SHA} and circle_job_name = ${CIRCLE_JOB} already exists. Skipping build"
+            ./scripts/get_last_image "${PROVIDER}" "${MONOREPO_CONTENT_SHA}" "${CIRCLE_JOB}" && {
+                echo "${PROVIDER} image with monorepo_content_sha = ${MONOREPO_CONTENT_SHA} and circle_job_name = ${CIRCLE_JOB} already exists. Skipping build"
               } || packer build \
               -machine-readable \
-              --only amazon-ebs \
+              --only "${PROVIDER}" \
+              --var project_id="${CLOUDSDK_CORE_PROJECT}" \
+              --var account_file=/tmp/gce-credentials.json \
+              --var gce_zone="${GCE_DEFAULT_ZONE}" \
               --var monorepo_content_sha="${MONOREPO_CONTENT_SHA}" \
               --var image_family_suffix="${IMAGE_FAMILY_SUFFIX}" \
               --var ami_region="${AWS_DEFAULT_REGION}" \
               --var windows_user="${WINDOWS_USER}" \
               --var test_results_path="/tmp/results/test-results.xml" \
               ${SOURCE_IMAGE_VAR} \
-              \
-              windows/visual-studio/packer.json | tee /tmp/artifacts/amazon-ebs-build.log
+              windows/visual-studio/packer.json | tee /tmp/artifacts/image-build.log
       - run:
           name: Summarize results
           command: |
-            BUILD_LOG_PATH="/tmp/artifacts/amazon-ebs-build.log"
+            MONOREPO_CONTENT_SHA="$(./scripts/get_content_sha windows)"
+            BUILD_LOG_PATH="/tmp/artifacts/image-build.log"
             if [[ -f $BUILD_LOG_PATH ]]; then
               IMAGE_NAME=$(grep 'artifact,0,id' "${BUILD_LOG_PATH}" | cut -d, -f6 | cut -d: -f2 || echo '')
               echo Recording just-built image $IMAGE_NAME as the output of this job
             else
-              MONOREPO_CONTENT_SHA="$(./scripts/get_content_sha windows)"
-
-              IMAGE_NAME=$(./scripts/get_last_image "${MONOREPO_CONTENT_SHA}" "${CIRCLE_JOB}")
+              IMAGE_NAME=$(./scripts/get_last_image "${PROVIDER}" "${MONOREPO_CONTENT_SHA}" "${CIRCLE_JOB}")
               echo Nothing to build, recording previously-built image $IMAGE_NAME as the output of this job
             fi
 
@@ -83,18 +120,92 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+jobs:
+  gc_old_ec2_instances:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - run:
+          name: check that it should work for AWS
+          command: |
+            if [ ! -z "${AWS_ACCESS_KEY_ID}" ]
+            then
+              circleci-agent step halt
+            fi
+      - checkout
+      - run: sudo pip3 install awscli
+      - run: sudo apt-get update && sudo apt-get install jq
+      - run: scripts/gc-ec2-instances.sh
+
+  gc_old_gce_instances:
+    docker:
+      - image: google/cloud-sdk:263.0.0-alpine
+    steps:
+      - run:
+          name: generate credentials or halt the job
+          command: |
+            if [ ! -z "${GCE_SERVICE_CREDENTIALS_BASE64}" ]
+            then
+              echo "${GCE_SERVICE_CREDENTIALS_BASE64}" \
+                | base64 -d \
+                > /tmp/gce-credentials.json
+            else
+              circleci-agent step halt
+            fi
+      - run: |
+          gcloud auth activate-service-account --key-file /tmp/gce-credentials.json
+          apk add --no-cache coreutils
+      - run:
+          name: Create GC script, then run it
+          command: |
+            cat \<<"EOF" > /usr/local/bin/run-gc
+            #!/bin/bash
+            #
+            # Stops any RUNNING packer VMs that are older than 48 hours. You can
+            # also pass a max age, in hours, for running VMs.
+            #
+            # IMPORTANT: Please be extremely cautious if editing this script as
+            # these instances are in the same project as our production VMs. A
+            # missing or incorrect filter could easily delete all existing VMs
+            # out from under us.
+            set -euo pipefail
+            MAX_AGE_HOURS=${1:-"48"}
+            DAYS_AGO=$(date -u -Iseconds --date="$MAX_AGE_HOURS hours ago")
+            gcloud compute instances list \
+              --filter="status=(RUNNING,TERMINATED) AND name~packer-.+ AND creationTimestamp < ${DAYS_AGO}" \
+              --project=${CLOUDSDK_CORE_PROJECT} \
+              --format='csv[no-heading,separator=" "](name,zone)' > /tmp/instances.csv
+            while read name zone; do
+              gcloud compute instances delete \
+                --zone ${zone} \
+                --quiet \
+                $name
+            done < /tmp/instances.csv
+            EOF
+            chmod +x /usr/local/bin/run-gc
+
+            /usr/local/bin/run-gc
+
+  windows_visualstudio_gcp: *build_image
+
+  windows_visualstudio_aws: *build_image
+
 workflows:
   version: 2
 
   build_all_images:
     jobs:
+      - windows_visualstudio_gcp:
+          context: circleci-server-image-builder
       - windows_visualstudio_aws:
-          context: circleci-server-ami-builder
+          context: circleci-server-image-builder
 
   daily:
     jobs:
+      - gc_old_gce_instances:
+          context: circleci-server-image-builder
       - gc_old_ec2_instances:
-          context: circleci-server-ami-builder
+          context: circleci-server-image-builder
     triggers:
       - schedule:
           cron: "17 12 * * *"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ This folder contains everything you will need to build a Windows image, with the
 
 ## Building a Windows Image to use with `machine` Executor
 
-The following steps will guide you through building a Windows AMI, which you can then specify in the VM Service settings for your installation of CircleCI Server, letting users of your installation run their builds in a Windows environment.
+The following steps will guide you through building a Windows AMI, which you can then specify in the VM Service settings for your installation of CircleCI server, letting users of your installation run their builds in a Windows environment.
 
 Please note that Windows images are built on CircleCI, so we suggest you run through this process once your installation is up and running. Alternatively you can use any other CircleCI account – including on our managed Cloud service.
 
 ### Step-by-step guide
+
+You can use either AWS or GCP to build your Windows machine image. Choose one your server instance is running.
+
+#### For AWS
 
 1. Prerequisites:
 
@@ -16,19 +20,43 @@ Please note that Windows images are built on CircleCI, so we suggest you run thr
 
     2. Make sure that you have **an access key** for an AWS IAM User that has sufficient permission to create AMIs using Packer. Refer to [documentation of Packer](https://www.packer.io/docs/builders/amazon#authentication) for details.
 
-2. First, **configure `circleci-server-ami-builder` context that contains a required AWS access key as env vars**. In `ami-builder` context, populate the env vars below:
+2. First, **configure `circleci-server-image-builder` context that contains a required AWS access key as env vars**. In the context, populate the env vars below:
 
     * `AWS_ACCESS_KEY_ID` (Access key ID of your access key)
     * `AWS_SECRET_ACCESS_KEY` (Secret access key of your access key)
-    * `AWS_DEFAULT_REGION` (Region where your CircleCI Server is hosted, e.g. us-east-1, us-west-1, ap-noartheast-1. Created AMI will be available only for this region.)
+    * `AWS_DEFAULT_REGION` (Region where your CircleCI server is hosted, e.g., `us-east-1`, `us-west-1`, `ap-noartheast-1`. Created AMI will be available only for this region.)
 
     [Our official document](https://circleci.com/docs/2.0/contexts/) would help you setting up contexts.
 
-3. **Create a new project on your CircleCI Server to connect your own repo** by clicking Set Up Project in the Add Projects page.
+3. **Create a new project on your CircleCI server to connect your own repo** by clicking Set Up Project in the Add Projects page.
 
 4. After project setup, the first build would run automatically. Wait for it to complete; it would take 2 - 3 hours to finish.
 
 5. You will find your new Windows AMI ID at the end of the `summarize results` step in the job output.
+
+#### For GCP
+
+1. Prerequisites:
+
+    1. Make sure that you have **your own copy of this repository** on your GitHub organization.
+
+    2. Make sure that you have **a JSON-formatted key for a GCP service account** that has sufficient permission to create GCE images using Packer. Refer to [documentation of Packer](https://www.packer.io/docs/builders/googlecompute#running-outside-of-google-cloud) for details.
+
+    3. Make sure that the `default` network for your working project (which is specified in `CLOUDSDK_CORE_PROJECT` as described below) has **a firewall rule that allows ingress connections to TCP port 5986 of machines with a `packer-winrm` tag**.
+
+2. First, **configure `circleci-server-image-builder` context that contains credentials for GCE as env vars**. In the context, populate the env vars below:
+
+    * `GCE_SERVICE_CREDENTIALS_BASE64` (Base64-encoded service account key; the result of `base64 -w 0 your-key-file.json`)
+    * `CLOUDSDK_CORE_PROJECT` (Name of the project for which the image builder runs and the resulting image is saved)
+    * `GCE_DEFAULT_ZONE` (Zone where the image builder runs, e.g., `us-central1-a`, `asia-northeast1-a`.)
+
+    [Our official document](https://circleci.com/docs/2.0/contexts/) would help you setting up contexts.
+
+3. **Create a new project on your CircleCI server to connect your own repo** by clicking Set Up Project in the Add Projects page.
+
+4. After project setup, the first build would run automatically. Wait for it to complete; it would take 2 - 3 hours to finish.
+
+5. You will find your new Windows image ID at the end of the `summarize results` step in the job output.
 
 ### Common troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can use either AWS or GCP to build your Windows machine image. Choose one yo
 
 ### Common troubleshooting
 
-* If you get any errors around not being able to find a default VPC, you will need to specify `vpc_id` and `subnet_id` in `windows/visual-studio/packer.yaml`.
+* If you get any errors around not being able to find a default VPC, you will need to specify `vpc_id`, `subnet_id` (both for AWS) or `subnetwork` (for GCP) in `windows/visual-studio/packer.yaml`.
 
 ## What the packer job in this build does
 * Sets up winrm.

--- a/scripts/get_last_image
+++ b/scripts/get_last_image
@@ -4,8 +4,9 @@ set -euo pipefail
 # Returns the most recent image that has already been built from the given
 # Circle job with the given content hash. Fails if nothing is found.
 
-# Usage: get_last_image SHA CIRCLE_JOB REGION
+# Usage: get_last_image PROVIDER SHA CIRCLE_JOB REGION
 #
+# PROVIDER:   one of the following providers [ googlecompute | amazon-ebs ]
 # SHA:        the hash of a directory of packer config used to build this image
 # CIRCLE_JOB: the circle job that built this image
 # AWS REGION: the aws region to look for this image in
@@ -14,11 +15,46 @@ set -euo pipefail
 #           (image name in GCE, AMI id in AWS)
 # exit:     0 if at least one image is returned, 1 if no images are returned
 
-MONOREPO_CONTENT_SHA="${1}"
-JOB_NAME="${2}"
-REGION="${3:-$AWS_DEFAULT_REGION}"
-RESPONSE="$(aws ec2 describe-images --filters Name="tag:monorepo_content_sha,Values=${MONOREPO_CONTENT_SHA}" Name="tag:circle_job_name,Values=${JOB_NAME}" --query Images[*] --region "${REGION}")"
-IMAGE=$(echo "${RESPONSE}" | jq --raw-output '.[].ImageId' | sort -r | head -n 1)
+PROVIDER="${1}"
+MONOREPO_CONTENT_SHA="${2}"
+JOB_NAME="${3}"
+REGION="${4:-}"
+
+if [[ $REGION == "" ]]; then
+  if [[ $PROVIDER == "googlecompute" ]]; then
+    REGION="$(echo "${GCE_DEFAULT_ZONE}" | awk -F'-' '{ print $1 }')"
+  elif [[ $PROVIDER == "amazon-ebs" ]]; then
+    REGION="$AWS_DEFAULT_REGION"
+  fi
+fi
+
+case "${PROVIDER}" in
+googlecompute)
+  CLEAN_JOB_NAME=$(echo "${JOB_NAME}" | sed "s/[^a-zA-Z0-9-]/-/g")
+  # despite the fact that image region is now extremely important for
+  # determining costs, GCE has no way to filter images by their storage
+  # location, which is totally fine. Another hilarious thing is that if you use
+  # `gcloud beta compute images list` you get an empty list back, while `gcloud
+  # compute images list` is definitely not empty. This removes the option of
+  # listing possibly-relevant images and then filtering down by region.
+  #
+  # So instead we label every image we make with the region it's in.
+  #
+  # Once again: this is completely fine.
+  filters="labels.monorepo_content_sha=${MONOREPO_CONTENT_SHA} AND labels.circle_job_name=${CLEAN_JOB_NAME} AND labels.region~^${REGION}$"
+  RESPONSE="$(./google-cloud-sdk/bin/gcloud compute images list --filter="${filters}" --format=json)"
+  IMAGE=$(echo "${RESPONSE}" | jq --raw-output '.[].name' | sort -r | head -n 1)
+  ;;
+amazon-ebs)
+  RESPONSE="$(aws ec2 describe-images --filters Name="tag:monorepo_content_sha,Values=${MONOREPO_CONTENT_SHA}" Name="tag:circle_job_name,Values=${JOB_NAME}" --query Images[*] --region "${REGION}")"
+  IMAGE=$(echo "${RESPONSE}" | jq --raw-output '.[].ImageId' | sort -r | head -n 1)
+  ;;
+*)
+  echo "unknown provider ${PROVIDER}" >/dev/stderr
+  exit 1
+  ;;
+esac
+
 echo "Found $(echo "${RESPONSE}" | jq length) images for ${JOB_NAME} with SHA ${MONOREPO_CONTENT_SHA} in ${REGION}" >/dev/stderr
 echo "${IMAGE}"
 echo "${RESPONSE}" | jq -e '. | length > 0' >/dev/null

--- a/windows/visual-studio/packer.yaml
+++ b/windows/visual-studio/packer.yaml
@@ -1,4 +1,8 @@
 variables:
+  # GCE account related
+  project_id: notnoopci-prototype
+  account_file: ""
+
   # metadata for tagging
   circle_build_url: '{{ env "CIRCLE_BUILD_URL"}}'
   circle_job_name: '{{ env "CIRCLE_JOB" }}'
@@ -6,6 +10,9 @@ variables:
   test_script_folder: "C:\\tests"
   shutdown_script_folder: "C:\\shutdown-scripts"
   circle_sha: '{{ env "CIRCLE_SHA1" }}'
+  circle_hostname: '{{ split (env "CIRCLE_BUILD_URL") "/" 2 }}'
+  circle_workflow_id: '{{ env "CIRCLE_WORKFLOW_ID" }}'
+  gce_region: '{{ split (user "gce_zone") "-" 0 }}'
 
 builders:
   - type: amazon-ebs
@@ -43,6 +50,51 @@ builders:
     run_volume_tags:
       circle_build_url: '{{ user "circle_build_url" }}'
 
+  - type: googlecompute
+    image_name: windows-server-2019-vs2019-{{timestamp}}
+    image_family: windows-server-2019-vs2019
+    source_image_family: windows-2019-for-containers
+    # This used to be 80GB but visual studio consumed an addtional 30GB. So This
+    # Was Doubled
+    disk_size: 160
+    # This is pd-ssd so that virus scan happens at a reasonable speed.
+    disk_type: pd-ssd
+
+    # Virus scan is much faster on a machine with a larger modern processer.
+    machine_type: "n1-standard-8"
+
+    project_id: '{{ user "project_id" }}'
+    account_file: '{{ user "account_file" }}'
+    zone: '{{ user "gce_zone" }}'
+    tags:
+      - packer-winrm
+
+    state_timeout: "30m"
+
+    preemptible: false
+
+    communicator: "winrm"
+    winrm_username: '{{ user "windows_user" }}'
+    winrm_insecure: true
+    winrm_use_ssl: true
+    winrm_timeout: "30m"
+
+    metadata:
+      windows-startup-script-cmd: |
+        winrm set winrm/config/service/auth @{Basic=\"true\"}
+
+      windows-shutdown-script-ps1: |
+        & {{user `shutdown_script_folder`}}\GCEShutdownScript.ps1
+        & {{user `shutdown_script_folder`}}\ShutdownScript.ps1
+
+    image_labels:
+      region: '{{ user "gce_region" }}'
+      circle_hostname: '{{ user "circle_hostname" | clean_image_name }}'
+      circle_workflow_id: '{{ user "circle_workflow_id" | clean_image_name }}'
+      circle_job_name: '{{ user "circle_job_name" | clean_image_name }}'
+      circle_sha: '{{ user "circle_sha" | clean_image_name }}'
+      monorepo_content_sha: '{{ user "monorepo_content_sha" | clean_image_name }}'
+
 provisioners:
   - type: file
     source: "windows/ImageHelpers"
@@ -71,7 +123,6 @@ provisioners:
     elevated_password: "{{.WinRMPassword}}"
     scripts:
       - "windows/provision-scripts/dscConfig.ps1"
-
       # Uncomment below to change the system locale to Japan (CP932)
       # システム ロケールを日本 (CP932) にする場合は下記を有効にしてください
       # - "windows/provision-scripts/localize.ps1"

--- a/windows/visual-studio/packer.yaml
+++ b/windows/visual-studio/packer.yaml
@@ -66,6 +66,7 @@ builders:
     project_id: '{{ user "project_id" }}'
     account_file: '{{ user "account_file" }}'
     zone: '{{ user "gce_zone" }}'
+    subnetwork: default
     tags:
       - packer-winrm
 


### PR DESCRIPTION
This PR introduces capability of building Windows machine images for CircleCI server instances running on GKE.

Basically, the codes are deriving from those at `machine-executor-images`, and major changes were made because:

1. We need to think about backward compatibility with server 2.x, where config version 2.1 is not supported.
2. We need to think about cases where users are running their server instances outside of e.g., `us-east-1`.
3. We need to think about tags on generated images - GCP does not accept tag values longer than 63-character length, while build URLs on typical server instances can exceed that limit quite easily.