### PR TITLE
Removing redundant escape

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
       - run:
           name: Create GC script, then run it
           command: |
-            cat \<<"EOF" > /usr/local/bin/run-gc
+            cat <<"EOF" > /usr/local/bin/run-gc
             #!/bin/bash
             #
             # Stops any RUNNING packer VMs that are older than 48 hours. You can

--- a/windows/validation-scripts/microsoft-tools.Tests.ps1
+++ b/windows/validation-scripts/microsoft-tools.Tests.ps1
@@ -5,8 +5,8 @@
   It "4 versions of the sdk are installed" {
     $(dotnet --list-sdks).Split([System.Environment]::NewLine).Count | Should -EQ 4
   }
-  It "15 versions of the runtime are installed" {
-    $(dotnet --list-runtimes).Split([System.Environment]::NewLine).Count | Should -EQ 15
+  It "18 versions of the runtime are installed" {
+    $(dotnet --list-runtimes).Split([System.Environment]::NewLine).Count | Should -EQ 18
   }
 }
 


### PR DESCRIPTION
Removing a `\` that was needed for config version 2.1 but not for 2.0.