### PR TITLE
link to both versions of server docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  Example Packer Config For building Windows On CircleCI
 
-This folder contains everything you will need to build a Windows image, with the CircleCI dsc resources, on CircleCI. For more information on setting up VM service, which includes specifying your new Windows image for your users, see our [VM Service guide](https://circleci.com/docs/2.0/vm-service/#section=server-administration).
+This folder contains everything you will need to build a Windows image with the CircleCI dsc resources, on CircleCI. For more information on setting up VM service, which includes specifying your new Windows image for your users, see our VM service guides for [server v3.x](https://circleci.com/docs/2.0/server-3-operator-vm-service/) and [server v2.x](https://circleci.com/docs/2.0/vm-service/).
 
 ## Building a Windows Image to use with `machine` Executor
 
@@ -10,7 +10,7 @@ Please note that Windows images are built on CircleCI, so we suggest you run thr
 
 ### Step-by-step guide
 
-You can use either AWS or GCP to build your Windows machine image. Choose one your server instance is running.
+You can use either AWS or GCP to build your Windows machine image. Choose the one your server instance is running in.
 
 #### For AWS
 


### PR DESCRIPTION
The windows image builder is for both server v2 and v3 so we need to link to both VM service guides.