### PR TITLE
sshd_config to enable SFTP subsystem

### DIFF
--- a/windows/provision-scripts/install-ssh.ps1
+++ b/windows/provision-scripts/install-ssh.ps1
@@ -55,6 +55,9 @@ AcceptEnv LANG LC_*
 SyslogFacility LOCAL0
 LogLevel DEBUG3
 
+# Enable SFTP subsystem
+# CircleCI runs `scp` to install a task runner, and newer `scp` implementation needs SFTP subsystem to be available
+Subsystem sftp sftp-server.exe
 "@
 
 Set-Content "$env:PROGRAMDATA\ssh\sshd_config" $sshdConfig


### PR DESCRIPTION
Recent build-agent (`picard` containers on Nomad clients) has OpenSSH >= 9.0, [with which `scp` command is no longer based on SCP, and is on SFTP instead](https://www.openssh.com/txt/release-9.0). This PR follows that move and enables SFTP subsystem on ephemeral machines for Windows builds by default.