### PR TITLE
Replace the native sftp-server with MSYS-based one

### DIFF
--- a/windows/provision-scripts/install-ssh.ps1
+++ b/windows/provision-scripts/install-ssh.ps1
@@ -57,7 +57,7 @@ LogLevel DEBUG3
 
 # Enable SFTP subsystem
 # CircleCI runs `scp` to install a task runner, and newer `scp` implementation needs SFTP subsystem to be available
-Subsystem sftp sftp-server.exe
+Subsystem sftp /usr/lib/ssh/sftp-server
 "@
 
 Set-Content "$env:PROGRAMDATA\ssh\sshd_config" $sshdConfig


### PR DESCRIPTION
This change updates our use of SFTP Server in Windows images to use MSYS-based one (coming along with Git Bash), instead of the Windows native one bundled in Windows Server.

With our further investigation, we found out the the previous change introduced another problem that `scp` for build-agent inner would fail, complaining that the destination doesn't exist. We identified that this happened because we configured OpenSSH Server to use Windows-native SFTP server; with this, paths passed through `scp` commands have been interpreted as if it's a native Windows path. Actually the preceding `mkdir` command is executed using MSYS-based Bash, and thus the native interpretation would result in an non-existent path.

This change updates the path for SFTP Server to use the one coming from Git Bash. In this way, paths will be interpreted as a UNIX-like path, which would yield a special interpretation by MSYS.

While the author of this PR hasn't E2E-tested the change, the author verified that the resulting `sshd_config` should work, and that theoretically it should revive the original behaviour with the old SCP-based `scp`.

![image](https://user-images.githubusercontent.com/872612/234834131-a6ffdbd9-b738-402d-9952-57e5b16f3fdf.png)

P.S. With WPR Makoto verified that the value `/usr/lib/ssh/sftp-server` is internally interpreted using Git Bash. Makoto also verified that this shouldn't be a native Windows path (that would result in a "file not found" error).
![image](https://user-images.githubusercontent.com/872612/234833489-d2f57ad0-368c-4ecb-a4ce-11961172801d.png)
