### PR TITLE
Replace the native sftp-server with MSYS-based one

### DIFF
--- a/windows/provision-scripts/install-ssh.ps1
+++ b/windows/provision-scripts/install-ssh.ps1
@@ -57,7 +57,7 @@ LogLevel DEBUG3
 
 # Enable SFTP subsystem
 # CircleCI runs `scp` to install a task runner, and newer `scp` implementation needs SFTP subsystem to be available
-Subsystem sftp sftp-server.exe
+Subsystem sftp /usr/lib/ssh/sftp-server
 "@
 
 Set-Content "$env:PROGRAMDATA\ssh\sshd_config" $sshdConfig


### PR DESCRIPTION
More details in Makoto's PR: https://github.com/CircleCI-Public/circleci-server-windows-image-builder/pull/19
I am just copying his work so the tests will run and we can merge it in.