### PR TITLE
Feat: configure custom Docker Registry mirror if needed

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -7,3 +7,15 @@ The “default”,  “nvidia”, and “visual-studio” folders are various fl
 The “provision-scripts” folder contains a number of powershell scripts broken into software components.
 
 The "CircleCIDSCResources" repo contains automation objects that tell windows how it should configure it's self for us. These are being migrated to https://github.com/CircleCI-Public/CircleCIDSC
+
+
+## Custom Docker registry mirror
+
+You may want to set up [a custom Docker registry mirror](https://docs.docker.com/registry/recipes/mirror/) within this Windows AMI.
+
+To do so, you can simply:
+
+1. Uncomment the specific code sections in packer.yaml file.
+   * Look up the `# Uncomment below to enable Docker registry mirror` text.
+2. Replace https://mirror.gcr.io with your custom registry's URL.
+3. Ensure that this custom registry URL will will accessible for the Windows VM instances.

--- a/windows/provision-scripts/configure-docker-daemon.ps1
+++ b/windows/provision-scripts/configure-docker-daemon.ps1
@@ -36,14 +36,15 @@ if ($daemonConfig.'registry-mirrors' -eq $null) {
     $daemonConfig.'registry-mirrors' += $registryMirror
 }
 
-# Add or update insecure registry settings
-if ($daemonConfig.'insecure-registries' -eq $null) {
-    Write-Host "insecure-registries array missing. Creating record.."
-    $daemonConfig | add-member -type NoteProperty -Name 'insecure-registries' -Value @($registryMirror)
-} else {
-    Write-Host "insecure-registries array found. Appending record.."
-    $daemonConfig.'insecure-registries' += $registryMirror
-}
+# NOT RECOMMENDED: Add or update insecure registry settings
+# Uncomment code block below if your Docker registry mirror is not using HTTPS (insecure)
+# if ($daemonConfig.'insecure-registries' -eq $null) {
+#     Write-Host "insecure-registries array missing. Creating record.."
+#     $daemonConfig | add-member -type NoteProperty -Name 'insecure-registries' -Value @($registryMirror)
+# } else {
+#     Write-Host "insecure-registries array found. Appending record.."
+#     $daemonConfig.'insecure-registries' += $registryMirror
+# }
 
 # Save the modified configuration file
 $daemonConfig | ConvertTo-Json | Set-Content -Path $daemonConfigPath

--- a/windows/provision-scripts/configure-docker-daemon.ps1
+++ b/windows/provision-scripts/configure-docker-daemon.ps1
@@ -1,0 +1,57 @@
+# Set your Docker registry mirror via the DOCKERHUB_REGISTRY_MIRROR env var.
+$registryMirror = echo $Env:DOCKERHUB_REGISTRY_MIRROR
+if (-Not $registryMirror) {
+    Write-Host "No registry mirror set. Exiting early."
+    exit
+}
+
+# Check if Docker service is running
+$dockerService = Get-Service -Name Docker -ErrorAction SilentlyContinue
+if ($dockerService.Status -ne "Running") {
+    Write-Host "Docker service is not running."
+    exit
+}
+
+# Stop Docker service
+Stop-Service -Name Docker
+
+# Set the docker configutation
+$daemonConfigPath = "C:\ProgramData\Docker\config\daemon.json"
+
+# load or create Docker config JSON
+if (Test-Path -Path $daemonConfigPath -PathType Leaf) {
+    Write-Host "Docker config JSON exists."
+    $daemonConfig = Get-Content -Path $daemonConfigPath | ConvertFrom-Json
+} else {
+    Write-Host "Docker config JSON does not exist."
+    $daemonConfig = @{}
+}
+
+# Add or update registry mirror settings
+if ($daemonConfig.'registry-mirrors' -eq $null) {
+    Write-Host "registry mirror array missing. Creating record.."
+    $daemonConfig | add-member -type NoteProperty -Name 'registry-mirrors' -Value @($registryMirror)
+} else {
+    Write-Host "registry mirror array found. Appending record.."
+    $daemonConfig.'registry-mirrors' += $registryMirror
+}
+
+# Add or update insecure registry settings
+if ($daemonConfig.'insecure-registries' -eq $null) {
+    Write-Host "insecure-registries array missing. Creating record.."
+    $daemonConfig | add-member -type NoteProperty -Name 'insecure-registries' -Value @($registryMirror)
+} else {
+    Write-Host "insecure-registries array found. Appending record.."
+    $daemonConfig.'insecure-registries' += $registryMirror
+}
+
+# Save the modified configuration file
+$daemonConfig | ConvertTo-Json | Set-Content -Path $daemonConfigPath
+
+# inspect config
+Get-Content -Path $daemonConfigPath
+
+# Start Docker service
+Start-Service -Name Docker
+
+Write-Host "Docker Daemon has been configured to use the registry mirror."

--- a/windows/visual-studio/packer.yaml
+++ b/windows/visual-studio/packer.yaml
@@ -14,6 +14,9 @@ variables:
   circle_workflow_id: '{{ env "CIRCLE_WORKFLOW_ID" }}'
   gce_region: '{{ split (user "gce_zone") "-" 0 }}'
 
+  # Uncomment below to set a default Docker registry mirror
+  # dockerhub_registry_mirror: 'https://mirror.gcr.io'
+
 builders:
   - type: amazon-ebs
     access_key: ""
@@ -134,12 +137,20 @@ provisioners:
   - type: powershell
     elevated_user: '{{ user "windows_user" }}'
     elevated_password: "{{.WinRMPassword}}"
+    # Uncomment below to enable Docker registry mirror value to be passed as an environment variable
+    # NOTE: Packer will quote strings by default
+    # See https://developer.hashicorp.com/packer/docs/provisioners/shell#env_var_format
+    # environment_vars:
+    #   - DOCKERHUB_REGISTRY_MIRROR={{ user "dockerhub_registry_mirror" }}
     scripts:
       - "windows/provision-scripts/install-ssh.ps1"
       - "windows/provision-scripts/update-pester.ps1"
       - "windows/provision-scripts/enable-ec2launch.ps1"
       - "windows/provision-scripts/enable-cleanup.ps1"
       - "windows/provision-scripts/disable-windows-defender-scanner.ps1"
+      # Uncomment below to enable Docker registry mirror
+      # NOTE: this script requires the DOCKERHUB_REGISTRY_MIRROR environment variable
+      # - "windows/provision-scripts/configure-docker-daemon.ps1"
       - "windows/validation-scripts/run-pester.ps1"
 
   - type: file

--- a/windows/visual-studio/packer.yaml
+++ b/windows/visual-studio/packer.yaml
@@ -14,7 +14,7 @@ variables:
   circle_workflow_id: '{{ env "CIRCLE_WORKFLOW_ID" }}'
   gce_region: '{{ split (user "gce_zone") "-" 0 }}'
 
-  # Uncomment below to set the Docker registry mirror
+  # Uncomment below to enable Docker registry mirror
   # IMPORTANT: Replace https://mirror.gcr.io with your custom registry
   # dockerhub_registry_mirror: 'https://mirror.gcr.io'
 

--- a/windows/visual-studio/packer.yaml
+++ b/windows/visual-studio/packer.yaml
@@ -148,10 +148,10 @@ provisioners:
       - "windows/provision-scripts/update-pester.ps1"
       - "windows/provision-scripts/enable-ec2launch.ps1"
       - "windows/provision-scripts/enable-cleanup.ps1"
-      - "windows/provision-scripts/disable-windows-defender-scanner.ps1"
       # Uncomment below to enable Docker registry mirror
       # NOTE: this script requires the DOCKERHUB_REGISTRY_MIRROR environment variable
       # - "windows/provision-scripts/configure-docker-daemon.ps1"
+      - "windows/provision-scripts/disable-windows-defender-scanner.ps1"
       - "windows/validation-scripts/run-pester.ps1"
 
   - type: file

--- a/windows/visual-studio/packer.yaml
+++ b/windows/visual-studio/packer.yaml
@@ -14,7 +14,8 @@ variables:
   circle_workflow_id: '{{ env "CIRCLE_WORKFLOW_ID" }}'
   gce_region: '{{ split (user "gce_zone") "-" 0 }}'
 
-  # Uncomment below to set a default Docker registry mirror
+  # Uncomment below to set the Docker registry mirror
+  # IMPORTANT: Replace https://mirror.gcr.io with your custom registry
   # dockerhub_registry_mirror: 'https://mirror.gcr.io'
 
 builders:


### PR DESCRIPTION
This PR is to enable additional configurations for setting up [a custom Docker registry mirror](https://docs.docker.com/registry/recipes/mirror/).

This is based on an earlier **tested** work on behalf of a Server 3.x customer.

Original work's [diff here](https://github.com/CircleCI-Public/circleci-server-windows-image-builder/compare/master...kelvintaywl:circleci-server-windows-image-builder:custom-docker-registry-mirror?expand=1)


### next steps

- [ ] Port these changes to our https://github.com/CircleCI-Public/circleci-server-linux-image-builder