### PR TITLE
Update branch filter in config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
 filters: &filters
   branches:
     only: 
-    - main
+    - master
 
 
 library:


### PR DESCRIPTION
The main branch in this repo is still `master`, so updating the config to match that.