### PR TITLE
Configure both 2019/2022 to install only minimum dependencies by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  Example Packer Config For building Windows On CircleCI
 
-This folder contains everything you will need to build a Windows image with the CircleCI dsc resources, on CircleCI. For more information on setting up VM service, which includes specifying your new Windows image for your users, see our VM service guides for [server v3.x](https://circleci.com/docs/2.0/server-3-operator-vm-service/) and [server v2.x](https://circleci.com/docs/2.0/vm-service/).
+This folder contains everything you will need to build a Windows image with the CircleCI dsc resources, on CircleCI. For more information on setting up VM service, which includes specifying your new Windows image for your users, see our VM service guides for [server v4](https://circleci.com/docs/server/latest/operator/manage-virtual-machines-with-machine-provisioner/).
 
 ## Building a Windows Image to use with `machine` Executor
 
@@ -11,6 +11,10 @@ Please note that Windows images are built on CircleCI, so we suggest you run thr
 ### Step-by-step guide
 
 You can use either AWS or GCP to build your Windows machine image. Choose the one your server instance is running in.
+
+By default, these images now build on the minimum required dependencies. This allows a ~30 minute build time to verify that your CircleCI Server environment can run a Windows build. 
+
+If you'd like to have additional dependencies installed, please uncomment anything necessary for [windows-2019](https://github.com/CircleCI-Public/circleci-server-windows-image-builder/blob/master/windows2019/provision-scripts/dscConfig.ps1) or [windows-2022](https://github.com/CircleCI-Public/circleci-server-windows-image-builder/blob/master/windows2022/software.yml).
 
 #### For AWS
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please note that Windows images are built on CircleCI, so we suggest you run thr
 
 You can use either AWS or GCP to build your Windows machine image. Choose the one your server instance is running in.
 
-By default, these images now build on the minimum required dependencies. This allows a ~30 minute build time to verify that your CircleCI Server environment can run a Windows build. 
+By default, these images now build on the minimum required dependencies. This allows for a shorter build time to verify that your CircleCI Server environment can run a Windows build. 
 
 If you'd like to have additional dependencies installed, please uncomment anything necessary for [windows-2019](https://github.com/CircleCI-Public/circleci-server-windows-image-builder/blob/master/windows2019/provision-scripts/dscConfig.ps1) or [windows-2022](https://github.com/CircleCI-Public/circleci-server-windows-image-builder/blob/master/windows2022/software.yml).
 

--- a/windows2019/provision-scripts/dscConfig.ps1
+++ b/windows2019/provision-scripts/dscConfig.ps1
@@ -13,7 +13,7 @@ Configuration CircleBuildHost {
         #By default, this installs the required dependencies for a CircleCI job to run. 
         #Things such as the AWS CLI, Python, Golang will not be installed by default. 
         #Please uncomment anything you would like to have installed by default.
-        #CircleUsers and CircleBuildAgentPreReq are required.
+        #DO NOT delete CircleUsers and CircleBuildAgentPreReq, as they are required for CircleCI jobs to run.
 
         CircleUsers "users" { } # https://github.com/CircleCI-Public/CircleCIDSC/blob/main/DSCResources/CircleUsers/CircleUsers.schema.psm1
         CircleBuildAgentPreReq buildAgentPreReq { } # https://github.com/CircleCI-Public/CircleCIDSC/blob/main/DSCResources/CircleBuildAgentPreReq/CircleBuildAgentPreReq.schema.psm1

--- a/windows2019/provision-scripts/dscConfig.ps1
+++ b/windows2019/provision-scripts/dscConfig.ps1
@@ -10,12 +10,17 @@ Configuration CircleBuildHost {
             RebootNodeIfNeeded = $False
         }
 
-        CircleUsers "users" { }
-        CircleBuildAgentPreReq buildAgentPreReq { }
-        CircleCloudTools cloudTools { }
-        CircleDevTools devTools { }
-        CircleTDR tdr { }
-        CircleMicrosoftTools MicrosoftTools { }
+        #By default, this installs the required dependencies for a CircleCI job to run. 
+        #Things such as the AWS CLI, Python, Golang will not be installed by default. 
+        #Please uncomment anything you would like to have installed by default.
+        #CircleUsers and CircleBuildAgentPreReq are required.
+
+        CircleUsers "users" { } # https://github.com/CircleCI-Public/CircleCIDSC/blob/main/DSCResources/CircleUsers/CircleUsers.schema.psm1
+        CircleBuildAgentPreReq buildAgentPreReq { } # https://github.com/CircleCI-Public/CircleCIDSC/blob/main/DSCResources/CircleBuildAgentPreReq/CircleBuildAgentPreReq.schema.psm1
+        #CircleCloudTools cloudTools { } # https://github.com/CircleCI-Public/CircleCIDSC/blob/main/DSCResources/CircleCloudTools/CircleCloudTools.schema.psm1
+        #CircleDevTools devTools { } # https://github.com/CircleCI-Public/CircleCIDSC/blob/main/DSCResources/CircleDevTools/CircleDevTools.schema.psm1
+        #CircleTDR tdr { } # https://github.com/CircleCI-Public/CircleCIDSC/blob/main/DSCResources/CircleTDR/CircleTDR.schema.psm1
+        #CircleMicrosoftTools MicrosoftTools { } # https://github.com/CircleCI-Public/CircleCIDSC/blob/main/DSCResources/CircleMicrosoftTools/CircleMicrosoftTools.schema.psm1
     }
 }
 

--- a/windows2022/software.yml
+++ b/windows2022/software.yml
@@ -1,3 +1,8 @@
+#By default, this installs the required dependencies for a CircleCI job to run. 
+#Things such as the AWS CLI, Python, Golang will not be installed by default. 
+#Please uncomment anything you would like to have installed by default.
+#Git, Git-lfs, 7zip, gzip and sysinternals are required.
+
 # renovate: datasource=repology depName=chocolatey/git
 git_version: 2.46.2
 # renovate: datasource=repology depName=chocolatey/git-lfs
@@ -9,51 +14,51 @@ gzip_version: 1.3.12
 # renovate: datasource=repology depName=chocolatey/sysinternals
 sysinternals_version: 2024.7.23
 # renovate: datasource=repology depName=chocolatey/awscli
-awscli_version: 2.17.64
+#awscli_version: 2.17.64
 # renovate: datasource=repology depName=chocolatey/azure-cli
-azurecli_version: 2.64.0
+#azurecli_version: 2.64.0
 # renovate: datasource=repology depName=chocolatey/webpi
-webpi_version: 5.1
+#webpi_version: 5.1
 # renovate: datasource=repology depName=chocolatey/service-fabric-sdk
-servicefabricsdk_version: 7.1.2338
+#servicefabricsdk_version: 7.1.2338
 # renovate: datasource=repology depName=chocolatey/nunit-console-runner
-nunit_console_runner_version: 3.18.2
+#nunit_console_runner_version: 3.18.2
 # renovate: datasource=repology depName=chocolatey/nano
-nano_version: 7.2.36.20230412
+#nano_version: 7.2.36.20230412
 # renovate: datasource=repology depName=chocolatey/vim
-vim_version: 9.1.757
+#vim_version: 9.1.757
 # renovate: datasource=repology depName=chocolatey/jq
-jq_version: 1.7
+#jq_version: 1.7
 # renovate: datasource=repology depName=chocolatey/golang
-golang_version: 1.23.2
+#golang_version: 1.23.2
 # renovate: datasource=repology depName=chocolatey/openjdk
-openjdk_version: 22.0.2
+#openjdk_version: 22.0.2
 # renovate: datasource=repology depName=chocolatey/python
-python_3_version: 3.12.6
+#python_3_version: 3.12.6
 # renovate: datasource=repology depName=chocolatey/nodejs
-nodejs_version: 21.6.2
+#nodejs_version: 21.6.2
 # renovate: datasource=repology depName=chocolatey/ruby
-ruby_version: 3.3.0.1
+#ruby_version: 3.3.0.1
 # renovate: datasource=repology depName=chocolatey/rust
-rust_version: 1.81.0
+#rust_version: 1.81.0
 # renovate: datasource=repology depName=chocolatey/docker-engine
-docker_version: 25.0.3.20240227
+#docker_version: 25.0.3.20240227
 # renovate: datasource=repology depName=chocolatey/nvm
-nvm_version: 1.1.11
+#nvm_version: 1.1.11
 # renovate: datasource=repology depName=chocolatey/dotnet-6.0-sdk
-dotnet_sdk_version_6: 6.0.418
+#dotnet_sdk_version_6: 6.0.418
 # renovate: datasource=repology depName=chocolatey/dotnet-7.0-sdk
-dotnet_sdk_version_7: 7.0.405
+#dotnet_sdk_version_7: 7.0.405
 # renovate: datasource=repology depName=chocolatey/visualstudio2022community
-visualstudio_community_edition_version: 117.11.5
+#visualstudio_community_edition_version: 117.11.5
 # renovate: datasource=repology depName=chocolatey/visualstudio2022buildtools
-visualstudio_buildtools_version: 117.11.5
+#visualstudio_buildtools_version: 117.11.5
 # renovate: datasource=repology depName=chocolatey/NuGet.CommandLine
-nuget_cli_version: 6.11.1
+#nuget_cli_version: 6.11.1
 # renovate: datasource=repology depName=chocolatey/winappdriver
-winappdriver_version: 1.2.1
+#winappdriver_version: 1.2.1
 # renovate: datasource=repology depName=chocolatey/syft
-syft_version: 1.13.0
+#syft_version: 1.13.0
 package_state: present
 image_name: windows-server-2022-gui
 image_tag: 2024.01.1


### PR DESCRIPTION
Customers should know what is required to build a Windows image that will work with CircleCI. 
This PR changes the default behavior of the image to build with only the dependencies that are required to run in CircleCi. 

Customers can then verify if they need something and uncomment them as they see fit.